### PR TITLE
[LA.VENDOR.1.0.r1] Remove proprietary libraries

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -112,10 +112,8 @@ LOCAL_HEADER_LIBRARIES := \
     liblisten_headers
 
 LOCAL_SHARED_LIBRARIES := \
-    libar-gsl\
     liblog\
     libexpat\
-    liblx-osal\
     libaudioroute\
     libcutils \
     libagmclient


### PR DESCRIPTION
We do not want these (And cant) while building.

These will be included in ODM as blobs and loaded
on runtime.

Signed-off-by: Martin Botka [martin.botka@somainline.org](mailto:martin.botka@somainline.org)